### PR TITLE
Roi pot detection window

### DIFF
--- a/yolov8/ball/ball.py
+++ b/yolov8/ball/ball.py
@@ -18,6 +18,8 @@ class Ball:
         self.coordinate_history: list[list[float]] = []
         # Number of frames the ball has been missing since the last sighting
         self.missing_frame_count: int = 0
+        # The pocket and the ROIs the ball is in
+        self.pocket_roi: tuple[int, list[int]] | tuple[()] = ()
 
     def update_position(self, new_x: float, new_y: float, new_w: float, new_h: float) -> None:
         self.__direction_vector_is_current = False

--- a/yolov8/main.py
+++ b/yolov8/main.py
@@ -3,6 +3,7 @@ from PIL import Image
 from ultralytics import YOLO
 
 from yolov8.ball import Balls
+from yolov8.pockets import Pockets
 from yolov8.pot_detection import PotDetector
 from yolov8.table_segmentation import TableProjection
 from yolov8.user_input import UserInput
@@ -68,8 +69,11 @@ if video_inference:
     # Class to track ball state
     balls = Balls()
 
+    # Class to store the pockets and update which balls are in what pocket ROIs
+    pockets_tracker = Pockets(balls, pocket_coordinates, pocket_rois)
+
     # Class to detect pots
-    pot_detector = PotDetector(pocket_coordinates, pocket_rois, balls)
+    pot_detector = PotDetector(balls, pockets_tracker)
 
     # Loop through the video frames
     while cap.isOpened():
@@ -112,6 +116,9 @@ if video_inference:
 
             # Update the ball positions and metadata
             balls.update(results[0])
+
+            # Update the pocket rois for the balls
+            pockets_tracker(results[0])
 
             # Detect pots
             pot_detector(results[0], annotated_frame)

--- a/yolov8/pockets/__init__.py
+++ b/yolov8/pockets/__init__.py
@@ -1,0 +1,1 @@
+from .pockets import Pockets

--- a/yolov8/pockets/pockets.py
+++ b/yolov8/pockets/pockets.py
@@ -10,10 +10,13 @@ from yolov8.ball import Balls
 
 
 class Pockets:
+    """
+    Stores pocket information and updates which balls are in each pocket ROI.
+    """
     def __init__(self, balls: Balls, pocket_coordinates: list[list[int, int]], pocket_roi_radii: list[int]):
         self.balls = balls
         self.pocket_coordinates = pocket_coordinates
-        #  Sort RIO radii in descending order
+        #  Sort RIO radii in descending order so the largest ROI is checked first
         pocket_roi_radii = sorted(pocket_roi_radii, reverse=True)
         pocket_rois = {
             i: {
@@ -31,7 +34,12 @@ class Pockets:
             for i, pocket_coord in enumerate(pocket_coordinates)
         }
 
-    def __call__(self, detection_results: ultralytics.engine.results.Results):
+    def __call__(self, detection_results: ultralytics.engine.results.Results) -> None:
+        """
+        Update the state of the balls in the ROIs.
+
+        :param detection_results: Model detection results
+        """
         if not isinstance(detection_results, ultralytics.engine.results.Results):
             raise ValueError("Detection results must be of type ultralytics.engine.results.Results.")
 

--- a/yolov8/pockets/pockets.py
+++ b/yolov8/pockets/pockets.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import ultralytics
+
+from yolov8.ball import Balls
+
+# IDEA: Consider moving the ball_roi method into the Ball class and let the Balls class update and keep track of
+# which balls are in a roi (the ball would also know itself). This would involve this class being passed into the
+# Balls class. Currently, this doesn't make a difference.
+
+
+class Pockets:
+    def __init__(self, balls: Balls, pocket_coordinates: list[list[int, int]], pocket_roi_radii: list[int]):
+        self.balls = balls
+        self.pocket_coordinates = pocket_coordinates
+        #  Sort RIO radii in descending order
+        pocket_roi_radii = sorted(pocket_roi_radii, reverse=True)
+        pocket_rois = {
+            i: {
+                "r": radius,
+            }
+            for i, radius in enumerate(pocket_roi_radii)
+        }
+        # TODO: Do I create a Pocket class instead of using a dictionary?
+        self.pockets = {
+            i: {
+                "x": pocket_coord[0],
+                "y": pocket_coord[1],
+                "rois": pocket_rois.copy(),
+            }
+            for i, pocket_coord in enumerate(pocket_coordinates)
+        }
+
+    def __call__(self, detection_results: ultralytics.engine.results.Results):
+        if not isinstance(detection_results, ultralytics.engine.results.Results):
+            raise ValueError("Detection results must be of type ultralytics.engine.results.Results.")
+
+        detections = detection_results.boxes
+        if detections.id is None:
+            return
+
+        ball_ids = [int(ball_id) for ball_id in detections.id]
+        self.update_balls_in_rois(ball_ids)
+
+    def __ball_roi(self, ball_id: int) -> tuple[int, list[int]] | tuple[()]:
+        """
+        Check if a ball is in a region of interest.
+
+        :return: The pocket and the ROIs the ball is in or None if the ball is not in any ROI.
+        """
+        ball_center = (self.balls[ball_id].x, self.balls[ball_id].y)
+        for pocket_key, pocket in self.pockets.items():
+            rois_present = []
+            for roi_key, roi in pocket["rois"].items():
+                if abs(ball_center[0] - pocket["x"]) < roi["r"] and abs(ball_center[1] - pocket["y"]) < roi["r"]:
+                    rois_present.append(roi_key)
+                    continue
+
+                # If the ball is a previous ROI, return the pocket and the ROIs it's in since it can't be in the
+                # other pockets
+                if rois_present:
+                    return pocket_key, rois_present
+
+                # Stop checking if the ball is not in the first ROI since the ROIs are sorted in descending order
+                break
+        return ()
+
+    def update_balls_in_rois(self, ball_ids: list[int]) -> None:
+        """
+        Updates the state of the balls in the ROIs.
+        """
+        for ball_id in ball_ids:
+            ball_roi = self.__ball_roi(ball_id)
+            self.balls[ball_id].pocket_roi = ball_roi

--- a/yolov8/pot_detection/pocket_roi_heuristic.py
+++ b/yolov8/pot_detection/pocket_roi_heuristic.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import ultralytics.engine.results
 
+from yolov8.ball import Balls
+from yolov8.pockets import Pockets
+
 
 class PocketROIHeuristic:
     """
@@ -14,34 +17,13 @@ class PocketROIHeuristic:
     4. If the balls were in the closest ROIs, they are potted.
     """
 
-    balls_potted = []
+    # Number of frames a ball must be missing before it's considered potted
+    missing_frame_threshold = 30
 
-    def __init__(self, pocket_coordinates: list[list[int, int]], pocket_roi_radii: list[int], **kwargs):
-        self.pocket_coordinates = pocket_coordinates
-
-        #  Sort RIO radii in descending order
-        pocket_roi_radii = sorted(pocket_roi_radii, reverse=True)
-        pocket_rois = {
-            i: {
-                "r": radius,
-            }
-            for i, radius in enumerate(pocket_roi_radii)
-        }
-        self.pockets = {
-            i: {
-                "x": pocket[0],
-                "y": pocket[1],
-                "rois": pocket_rois.copy(),
-                "balls": [],
-            }
-            for i, pocket in enumerate(pocket_coordinates)
-        }
-
-        # Data structure to keep track of which roi each ball is in. Ball id followed by the list of ROIs it's in
-        # Structure: {ball_id: (pocket_id, [roi_id, ...])}
-        self.ball_states: dict[int, tuple[int, list[int]]] = {}
-
-        self.kwargs = kwargs
+    def __init__(self, balls: Balls, pockets: Pockets):
+        self.balls = balls
+        self.balls_potted: list[int] = []
+        self.pockets = pockets.pockets
 
     def __call__(self, detection_results: ultralytics.engine.results.Results) -> list[int]:
         """
@@ -52,64 +34,22 @@ class PocketROIHeuristic:
         """
         if not isinstance(detection_results, ultralytics.engine.results.Results):
             raise ValueError("Detection results must be of type ultralytics.engine.results.Results.")
-        current_ball_states = self.current_ball_state(detection_results)
-        balls_potted = self.detect(current_ball_states)
-        if balls_potted:
-            self.balls_potted += balls_potted
-        self.ball_states = current_ball_states
-        return balls_potted
 
-    def __ball_in_roi(self, ball_xywh: list[int]) -> tuple[int, list[int]] | None:
-        """
-        Check if a ball is in a region of interest.
+        self.detect()
+        return self.balls_potted
 
-        :return: The pocket and the ROIs the ball is in or None if the ball is not in any ROI.
-        """
-        ball_center = (int(ball_xywh[0]), int(ball_xywh[1]))
-        for pocket_key, pocket in self.pockets.items():
-            rois_present = []
-            for roi_key, roi in pocket["rois"].items():
-                if abs(ball_center[0] - pocket["x"]) < roi["r"] and abs(ball_center[1] - pocket["y"]) < roi["r"]:
-                    rois_present.append(roi_key)
-                    continue
-
-                # If the ball is a previous ROI, return the pocket and the ROIs it's in since it can't be in the
-                # other pockets
-                if rois_present:
-                    return pocket_key, rois_present
-
-                # Stop checking if the ball is not in the first ROI since the ROIs are sorted in descending order
-                break
-        return None
-
-    def current_ball_state(
-        self, detection_results: ultralytics.engine.results.Results
-    ) -> dict[int, tuple[int, list[int]]]:
-        """
-        Return the current state of the balls.
-        """
-        detections = detection_results.boxes
-
-        ball_states: dict[int, tuple[int, list[int]]] = {}
-        for i in range(len(detections.id)):
-            ball_rois = self.__ball_in_roi(detections.xywh[i])
-            if ball_rois:
-                ball_states[int(detections.id[i])] = ball_rois
-        return ball_states
-
-    def detect(self, current_ball_states: dict[int, tuple[int, list[int]]]) -> list[int]:
+    def detect(self):
         """
         Detects if a ball is potted.
         """
-        balls_potted: list[int] = []
-        # Get the balls that are not in the current state but are in the previous state
-        potential_potted_balls = set(self.ball_states.keys()) - set(current_ball_states.keys())
-        for ball_id in potential_potted_balls:
-            pocket_id, rois = self.ball_states[ball_id]
-            # TODO: Need to consider that the ball disappears for more than n frames
-            # The ball can only leave the pocket if it's in the last ROI only
-            if rois != [0]:
-                balls_potted.append(ball_id)
-                print(f"Ball {ball_id} potted in pocket {pocket_id}")
-
-        return balls_potted
+        for ball_id, ball in self.balls.items():
+            # Ball is potted if it is in a roi, is in the last ROI only, is missing for enough frames and not
+            # already potted
+            if (
+                ball.pocket_roi != ()
+                and ball.pocket_roi[1] != [0]
+                and ball.missing_frame_count > self.missing_frame_threshold
+                and ball_id not in self.balls_potted
+            ):
+                self.balls_potted.append(ball_id)
+                print(f"Ball {ball_id} potted in pocket {ball.pocket_roi[0]}")

--- a/yolov8/pot_detection/pot_detector.py
+++ b/yolov8/pot_detection/pot_detector.py
@@ -2,20 +2,19 @@ from __future__ import annotations
 import ultralytics
 
 from yolov8.ball import Balls
+from yolov8.pockets import Pockets
 from yolov8.pot_detection import PocketROIHeuristic, LinearExtrapolationHeuristic
 
 
 class PotDetector:
-    def __init__(self, pocket_coordinates: list[list[int, int]], pocket_rois: list[int], balls: Balls, **kwargs):
-        self.pocket_coordinates = pocket_coordinates
-        self.pocket_rois = pocket_rois
+    def __init__(self, balls: Balls, pockets: Pockets):
         self.balls = balls
 
         # Detects if a ball is potted based on pocket ROIs
-        self.pot_detector = PocketROIHeuristic(pocket_coordinates, pocket_rois)
+        self.pot_detector = PocketROIHeuristic(balls, pockets)
 
         # Predicts the path of balls
-        self.path_predictor = LinearExtrapolationHeuristic(balls, pocket_coordinates)
+        self.path_predictor = LinearExtrapolationHeuristic(balls, pockets)
 
     def __call__(self, detection_results: ultralytics.engine.results.Results, frame=None) -> None:
         # Detect pot using ROI heuristic
@@ -26,3 +25,6 @@ class PotDetector:
         self.path_predictor(detection_results)
         self.path_predictor.draw_ball_direction_lines(detection_results, frame)
         print(f"balls towards pockets: {self.path_predictor.get_potential_pots(detection_results.boxes.id)}")
+
+
+# Nabe is a nabe


### PR DESCRIPTION
## Change List
- New pockets class to store the pocket information and update the balls with their pocket ROI information on call
- Pockets instance passed into the pot detector
- ROI pot detector considers ball missing frames

## Design Consideration Notes
The method to update the ball's ROI information is currently in the Pockets class. However, this could be moved to the Balls class and the Pockets instance is passed into the Balls instances as a dependency. 